### PR TITLE
Add slack badge for slack invites

### DIFF
--- a/index.md
+++ b/index.md
@@ -20,8 +20,15 @@ For some pytroll examples, you can have a look at the [Pytroll Gallery](gallery.
 
 ## Getting in touch
 
-If you want to contact us, we will be very happy to chat with you oun the [pytroll slack](https://pytroll.slack.com) ([get an invitation](https://pytrollslackin.herokuapp.com/) or [look at the archives](https://pytroll.slackarchive.io)).
-Alternatively, you can use the following mailing list: <https://groups.google.com/group/pytroll>.
+<script async defer src="https://pytrollslackin.herokuapp.com/slackin.js"></script>
+
+If you want to contact us, we will be very happy to chat with you on the [PyTroll slack](https://pytroll.slack.com).
+To get access you must invite yourself to the slack team by clicking on the
+above badge image or go [here](https://pytrollslackin.herokuapp.com/).
+You see past conversations by
+[looking at the archives](https://pytroll.slackarchive.io)).
+
+Alternatively, you can send messages mailing list: <https://groups.google.com/group/pytroll>.
 
 ## Announcements
 


### PR DESCRIPTION
This adds an interactive badge to the main pytroll page so people can click to join the slack team. See [here](https://github.com/rauchg/slackin#realtime-demo) for the example and a link to a demo.

My one fear for this is that I'm pretty sure loading/requesting this badge be shown will require the heroku app (the application that allows people to self-invite) to start up. Currently this app sleeps when not in use and when it receives traffic it starts up and runs for 30 minutes if no more traffic is received and sleeps after that. We are currently using the free heroku app plan so we get 1000 hours per month of "on" time. Having this on the home page and/or on the satpy repository page could lead to a lot more usage. I'll try to monitor this after this is merged.