### PR TITLE
Add code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at <pytroll-conduct@lists.wisc.edu>. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/index.md
+++ b/index.md
@@ -42,6 +42,32 @@ from Monday November 26th to Friday November 30th.
 
 ![PCW@EUMETSAT](https://pbs.twimg.com/media/DtLsFVlW0AAjZPQ.jpg:large)
 
+## Code of Conduct
+
+All PyTroll projects and events follow a code of conduct. A link to the code
+of conduct can be found in the section below. It is also available in the
+``CODE_OF_CONDUCT.md`` file in the PyTroll package source repositories.
+
+This code of conduct applies to the
+project space (GitHub) as well as the public space online and offline when
+an individual is representing the project or the community. Online examples
+of this include the PyTroll Slack team, mailing list, and the PyTroll twitter
+account. This code of conduct also applies to in-person situations like
+PyTroll Contributor Weeks (PCW), conference meet-ups, or any other time when
+the project is being represented.
+
+Any violations of this code of conduct will be handled by the core maintainers
+of the project including David Hoese, Martin Raspaud, Adam Dybbroe, and Panu
+Lahtinen. If you wish to report one of the maintainers for a violation and are
+not comfortable with them seeing it, please contact one or more of the other
+maintainers to report the violation. Responses to violations will be
+determined by the maintainers and may include one or more of the following:
+
+- Verbal warning
+- Ask for public apology
+- Temporary or permanent ban from in-person events
+- Temporary or permanent ban from online communication (Slack, mailing list, etc)
+
 ## Links
 
 - [SatPy introduction at SciPy 2018, by David Hoese](https://www.youtube.com/watch?v=G-fz8L9xHIs)
@@ -51,3 +77,4 @@ from Monday November 26th to Friday November 30th.
 - [Memorandum of Understanding](pytroll_mou_20170222.pdf)
 - [PyTroll Shop](http://pytroll.spreadshirt.net/)
 - [PyTroll History SatPy](https://youtu.be/eBQi2G_fqXQ)
+- [Code of Conduct](CODE_OF_CONDUCT.md)


### PR DESCRIPTION
This PR adds an official code of conduct intended for the entire PyTroll project. In the spirit of inclusivity and making contributors feel welcome I thought it would be a good idea to set up an official document. This code of conduct is taken from https://www.contributor-covenant.org/. Here are other helpful links:

* https://www.contributor-covenant.org/faq
* https://www.slideshare.net/aeschright/enforcing-your-code-of-conduct-effective-incident-response
* https://opensource.guide/code-of-conduct/

I think PyTroll is relatively a small project so enforcing this may be difficult, but I think it is important that we do our best so this can be established early before it becomes a problem. If any of you (@adybbroe @mraspaud @pnuu) would not like to be one of the contacts for violations, let me know and I'll remove you. I've set up an email list specifically for code of conduct violations on the University of Wisconsin's WiscLists system.

Of course if you have any questions or concerns let me know.