### PR TITLE
Clean up contributor guidelines and package python 2 compatibility

### DIFF
--- a/guidelines.md
+++ b/guidelines.md
@@ -15,46 +15,59 @@
 - Language is US English.
 - We generally follow the pep-8 and pep-257
 - Indentation is 4 spaces (no tabs!)
-- Max line length is set to 80 chars, but up to 120 is tolerated.
+- Max line length is set to 120 characters
 - Every unit of code must be properly tested and documented.
-- Global constants are written in capital letters, eg. PLANK_CONSTANT if they are not modified in the module and should be placed at the top of the module.
-- About docstrings, we follow the [google style](https://google.github.io/styleguide/pyguide.html?showone=Comments#Comments)
-- Prepare to be Python3 compatible.
+- Global constants are written in capital letters, eg. PLANK_CONSTANT if they are not modified in the module and should
+  be placed at the top of the module.
+- About docstrings, we follow the
+  [google style](https://google.github.io/styleguide/pyguide.html?showone=Comments#Comments)
+- Python 2 support until end of 2019
 - When in doubt, read pep 20, the Zen of Python (see appendix A)
 
 ## Maintainability Guidelines
 
-- Functions/methods should not contain more than 15 lines of code (including blank lines and comments).
-- There should be a maximum of 3 branches in each function/method.
-- Functions/methods should not have more than 5 parameters. Think of bundling arguments in helper classes for example.
+- Functions/methods should limit lines of code (including blank lines and comments). We recommend 15 if possible.
+- There should be a maximum of 3 branches in each function/method. Separate and refactor functionality to other
+  functions/methods.
+- Functions/methods should limit number of parameters (~5 parameters). Think of bundling arguments in helper classes
+  for example.
 
 ## Style Checking
 
-In your IDE/editor, it is highly recommended to activate/install a plugin for/script a save hook for doing automatic style checks and/or corrections, eg autopep8, pylint, pyflakes
+In your IDE/editor, it is highly recommended to activate/install a plugin for/script a save hook for doing automatic
+style checks and/or corrections, eg autopep8, pylint, pyflakes. Most repositories will use the "stickler" github bot to
+automatically check pull requests for PEP8 with the `flake8` tool.
 
 ## Working with Github
 
-Before submitting your changes, make sure your code follow the coding style above, and that your changes are properly covered by tests and documented. Make sure you run a style checker (eg pylint) on your code.
+Before submitting your changes, make sure your code follow the coding style above, and that your changes are properly
+covered by tests and documented. Make sure you run a style checker (eg pylint) on your code.
 
-If you want to help develop a Pytroll package, the preferred way to contribute is to fork the original repository and submit a pull request with your proposed changes.
+If you want to help develop a Pytroll package, the preferred way to contribute is to fork the original repository and
+submit a pull request with your proposed changes.
 
 The workflow in a nutshell is to:
 - Fork the repository in github
 - Implement the fix (with a test), it can be multiple commits
-- Submit a pull request (PR) to the project owner making sure changes will be merged to the ‘develop’ or ‘pre-master’ branch.
-- If you need to make further changes after the PR is issued, just push your commits to your fork: they will automatically be appended to the PR.
+- Submit a pull request (PR) to the original upstream repository. Describe your changes and why they were needed.
+  Make sure to link to any related issues or pull requests by using `#179` syntax to reference the number.
+- If you need to make further changes after the PR is issued, push your new commits to your fork's branch: they will
+  automatically be appended to the PR.
 
-Pull requests should avoid committing or adding unused files (ex. .pyc files). Even if they are deleted in future commits they should be purged from the commit history. See [this github article](https://help.github.com/articles/removing-sensitive-data-from-a-repository/) for instructions.
+Pull requests should avoid committing or adding unused files (ex. .pyc files). Even if they are deleted in future
+commits they should be purged from the commit history. See
+[this github article](https://help.github.com/articles/removing-sensitive-data-from-a-repository/) for instructions.
 
 - How to [create a Pull Request](https://help.github.com/articles/creating-a-pull-request/)
 - How to [fork a repository](https://help.github.com/articles/fork-a-repo/)
 
 Alternatively, patches formatted with the git format-patch command can be sent to the bdfl of the package.
 
-The submitted work will be reviewed by the main contributors of the package, possibly engaging in a discussion on the patch, and maybe requesting changes. Be prepared to follow up on your work.
+The submitted work will be reviewed by the main contributors of the package, possibly engaging in a discussion on
+the patch, and maybe requesting changes. Be prepared to follow up on your work.
 
 Commit messages:
-- Separate subject from body with a blank line
+- Separate subject from body with a blank line (see "How to" link below)
 - Limit the subject line to 50 characters
 - Capitalize the subject line
 - Do not end the subject line with a period
@@ -70,7 +83,8 @@ Commit messages:
 
 Versioning: [SemVer](http://semver.org/)
 
-The procedure for releasing is provided [here](https://github.com/pytroll/pytroll/wiki/Making-a-release)
+The procedure for releasing should be provided in each repository in a `RELEASING.md`
+or similarly named file.
 
 ## Appendix A
 

--- a/pytroll_packages_overview.md
+++ b/pytroll_packages_overview.md
@@ -1,16 +1,24 @@
 # PyTroll package summary overview, dependencies, level of maturity and usage
 
-Below is a short overview of all packages developed by and/or maintained by the PyTroll community. Included is their level of maturity, mutual interdependencies, and known operational usage (as of March 2018).
+Below is a short overview of all packages developed by and/or maintained by the PyTroll community. Included is their
+level of maturity, mutual interdependencies, and known operational usage (as of March 2018).
 
-There is a great spread in the size and complexity of the packages, and they may address rather different issues related to the processing and handling of satellite data.
+There is a great spread in the size and complexity of the packages, and they may address rather different issues
+related to the processing and handling of satellite data.
 
-If you are new to PyTroll, and have some satellite data you want to read and display, you should start out by getting familiar with SatPy!
+If you are new to PyTroll, and have some satellite data you want to read and display, you should start out by getting
+familiar with SatPy!
 
 ## All general PyTroll packages
 
+All packages are python 2 and 3 compatible unless specified otherwise. Python 2 support is not guaranteed after 2019.
+See the individual package documentation for details.
+
 ### SatPy
 
-* **Summary**: Python package for earth-observing satellite data processing. Reading many level-1 and -2 products, resamples the data, generates composite RGB imagery, and saves in a few standard formats such as netCDF, geoTIFF or png. Satpy is replacing Mpop (see below).
+* **Summary**: Python package for earth-observing satellite data processing. Reading many level-1 and -2 products,
+               resamples the data, generates composite RGB imagery, and saves in a few standard formats such as netCDF,
+               geoTIFF or png. Satpy is replacing Mpop (see below).
 
 * **Development intensity**: High
 

--- a/pytroll_packages_overview.md
+++ b/pytroll_packages_overview.md
@@ -11,8 +11,10 @@ familiar with SatPy!
 
 ## All general PyTroll packages
 
-All packages are python 2 and 3 compatible unless specified otherwise. Python 2 support is not guaranteed after 2019.
-See the individual package documentation for details.
+All packages are python 2.7 and 3.4+ compatible unless specified otherwise. See the individual package documentation
+for details or limitations. Due to the deprecation of Python 2, support in Pytroll packages is not guaranteed after
+2019. If a package below does not work on a certain version of python please file a bug in the appropriate github
+repository.
 
 ### SatPy
 


### PR DESCRIPTION
Close #5 and address issues discussed in https://github.com/pytroll/satpy/pull/659.

@mraspaud and @adybbroe as discussed in #5 by @gerritholl, we should mention python 2/3 compatibility for each package. I'm not sure the best way to do this and I'm also not familiar with the status of each package. Should we maybe mark some as deprecated or even remove them from the list?