### PR TITLE
Do not start line with number, this turns into ol

### DIFF
--- a/pytroll_packages_overview.md
+++ b/pytroll_packages_overview.md
@@ -12,8 +12,8 @@ familiar with SatPy!
 ## All general PyTroll packages
 
 All packages are python 2.7 and 3.4+ compatible unless specified otherwise. See the individual package documentation
-for details or limitations. Due to the deprecation of Python 2, support in Pytroll packages is not guaranteed after
-2019. If a package below does not work on a certain version of python please file a bug in the appropriate github
+for details or limitations. Due to the deprecation of Python 2, support in Pytroll packages is not guaranteed
+after 2019. If a package below does not work on a certain version of python please file a bug in the appropriate github
 repository.
 
 ### SatPy


### PR DESCRIPTION
Do not start the line with a number, as github pages turns this into an ordered list, such that the number 2019 now does not occur at all on http://pytroll.github.io/pytroll_packages_overview.html and instead an ordered list starts: "is not guaranteed after \ \ 1. If a package..."  Moving the word `after` to the next line should fix this (although I don't know how to test this).