### PR TITLE
add DWD to pyninjotiff 24/7 production

### DIFF
--- a/pytroll_packages_overview.md
+++ b/pytroll_packages_overview.md
@@ -336,7 +336,7 @@ repository.
 
 * **Other dependencies**: NumPy, Six
 
-* **24/7 production @**: MeteoSwiss
+* **24/7 production @**: MeteoSwiss, DWD
 
 ### Pytroll-db
 


### PR DESCRIPTION
For pyninjotiff, add DWD to the list of institutes using this package in 24/7 production.