### PR TITLE
[WIP] Add Pytroll governance document

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -1,0 +1,59 @@
+# Pytroll Governance
+
+## Summary
+
+This document formalizes the governance process for software projects under
+the Pytroll organization's umbrella. Anyone wishing to participate in the work
+done by the Pytroll community, whether it be software development, workshops,
+or any other method of community engagement, may do so. How decisions are
+made for individual projects as well as the Pytroll community in general are
+described below. 
+
+## Roles and Responsibilities
+
+### The Community
+
+TODO
+
+### Contributors
+
+TODO
+TODO: Create a separate section for people between basic contributor and core developer?
+
+### Core Project Developers
+
+TODO
+
+### Steering Council
+
+TODO
+TODO: groups.io email?
+
+## Decision Making Process
+
+TODO: Where communication takes place (slack, github issues, github pull requests)
+TODO: Consensus-seeking, starts with core devs, moves to steering council after that
+
+Decisions for individual projects and the overall community including the
+following cases are made according to the rules described below:
+
+* Changes to core project developers or steering council membership: TODO
+
+* Adding projects to or removing projects from the Pytroll organization: TODO
+
+* Minor documentation changes: TODO (1 core, lazy consensus)
+
+* Code changes and major documentation changes:
+  TODO (2 core, may include the contributor, lazy consensus)
+
+* Changes to API principles and backwards incompatible changes:
+  TODO (2 core, not including the contributor)
+
+* Changes to this governance model, the pytroll manifesto, code of conduct,
+  or pytroll coding guidelines: (steering council - simple majority)
+
+## Copyright
+
+This document is based on the
+[scikit-image governance document](https://scikit-image.org/docs/dev/skips/1-governance.html)
+and is placed in the public domain.


### PR DESCRIPTION
## Overview

This PR adds the initial governance document for the entire Pytroll organization. As discussed during last week's status meeting, I think it would be a good idea for us to define the decision making process. It should help explain how and why decisions are made in the Pytroll community and the software projects under the Pytroll organization.

As mentioned during the call, this is based on the scikit-image governance document (https://scikit-image.org/docs/dev/skips/1-governance.html), but removes the need for official "improvement proposal" documents.

I understand if this seems unnecessary; along the lines of "everything is going fine as is". However, I think this helps newcomers know how things work and helps us if we have disagreements in the future.

I'm marking this as a WIP since there are currently a lot of TODOs, but I wanted to get feedback before I spend a ton of time on the exact language.

## Other thoughts

1. Add a label for steering council decisions (or maybe just "governance")?
2. Noticed their is a "Pytroll Manifest" document, I think this is supposed to be "Manifesto".
3. Steering council: Who's in it? It probably shouldn't be an even number, so 5 people? Panu, Adam, Martin, Me, and Stephan or Sauli?
4. Do we want to define some kind of periodic review of the steering council?
5. Other terminology?