### PR TITLE
Update the packages overview

### DIFF
--- a/pytroll_packages_overview.md
+++ b/pytroll_packages_overview.md
@@ -330,7 +330,7 @@ individual package documentation for details or limitations.
 
 * **Docs**: 
 
-* **Pytroll dependencies**: None
+* **Pytroll dependencies**: Satpy, Posttroll, Pyorbital, Trollsift
 
 * **Optional Pytroll dependencies**: None
 

--- a/pytroll_packages_overview.md
+++ b/pytroll_packages_overview.md
@@ -1,22 +1,22 @@
-# PyTroll package summary overview, dependencies, level of maturity and usage
+# Pytroll package summary overview, dependencies, level of maturity and usage
 
-Below is a short overview of all packages developed by and/or maintained by the PyTroll community. Included is their
+Below is a short overview of all packages developed by and/or maintained by the Pytroll community. Included is their
 level of maturity, mutual interdependencies, and known operational usage (as of March 2018).
 
 There is a great spread in the size and complexity of the packages, and they may address rather different issues
 related to the processing and handling of satellite data.
 
-If you are new to PyTroll, and have some satellite data you want to read and display, you should start out by getting
-familiar with SatPy!
+If you are new to Pytroll, and have some satellite data you want to read and display, you should start out by getting
+familiar with Satpy!
 
-## All general PyTroll packages
+## All general Pytroll packages
 
-All packages are python 2.7 and 3.4+ compatible unless specified otherwise. See the individual package documentation
-for details or limitations. Due to the deprecation of Python 2, support in Pytroll packages is not guaranteed
-after 2019. If a package below does not work on a certain version of python please file a bug in the appropriate github
-repository.
+All packages require Python 3 (Python 2 is no longer supported).
+The specific version required varies per package but usually packages support at
+least the versions of Python released in the last 2--3 years.  See the
+individual package documentation for details or limitations.
 
-### SatPy
+### Satpy
 
 * **Summary**: Python package for earth-observing satellite data processing. Reading many level-1 and -2 products,
                resamples the data, generates composite RGB imagery, and saves in a few standard formats such as netCDF,
@@ -30,9 +30,9 @@ repository.
 
 * **Docs**: <https://satpy.readthedocs.io>
 
-* **PyTroll dependencies**: PyResample, PyKdtree, Trollimage, Trollsift
+* **Pytroll dependencies**: Pyresample, Pykdtree, Trollimage, Trollsift
 
-* **Optional PyTroll dependencies**: PySpectral, PyOrbital, PyGAC, Mipp, Python-geotiepoints, Pytroll-schedule.
+* **Optional Pytroll dependencies**: Pyspectral, Pyorbital, PyGAC, Python-geotiepoints, Pytroll-schedule.
 
 * **Other dependencies**: NumPy, Pillow, Pyyaml, Six
 
@@ -40,7 +40,7 @@ repository.
 
 ### Trollimage:
 
-* **Summary**: Imaging package for pytroll
+* **Summary**: Imaging package for Pytroll
 
 * **Development intensity**: Medium
 
@@ -50,15 +50,15 @@ repository.
 
 * **Maturity**: Mature
 
-* **PyTroll dependencies**: None
+* **Pytroll dependencies**: None
 
-* **Optional PyTroll dependencies**: None
+* **Optional Pytroll dependencies**: None
 
 * **Other dependencies**: NumPy, Pillow, Six
 
 * **24/7 production @**: FMI, SMHI, MeteoSwiss, ESTEA, LEGMC, IMO, ECCC, ...
 
-### PyOrbital:
+### Pyorbital:
 
 * **Summary**: Orbital and astronomy computations in python
 
@@ -70,15 +70,15 @@ repository.
 
 * **Maturity**: Mature
 
-* **PyTroll dependencies**: None
+* **Pytroll dependencies**: None
 
-* **Optional PyTroll dependencies**: None
+* **Optional Pytroll dependencies**: None
 
 * **Other dependencies**: NumPy
 
 * **24/7 production @**: FMI, SMHI, DMI, ESTEA, LEGMC, IMO, ECCC, Met Norway, ...
 
-### PyResample:
+### Pyresample:
 
 * **Summary**: Geospatial image resampling in Python
 
@@ -90,9 +90,9 @@ repository.
 
 * **Maturity**: Mature
 
-* **PyTroll dependencies**: PyKDTree
+* **Pytroll dependencies**: PyKDTree
 
-* **Optional PyTroll dependencies**: None
+* **Optional Pytroll dependencies**: None
 
 * **Other dependencies**: Pyproj, NumPy, Pyyaml, Six, confiobj, setuptools, Numexpr (optional), Dask (optional), Matplotlib (optional), Basemap (optional), Pillow (optional)
 
@@ -110,9 +110,9 @@ repository.
 
 * **Maturity**: Mature
 
-* **PyTroll dependencies**: None
+* **Pytroll dependencies**: None
 
-* **Optional PyTroll dependencies**: None
+* **Optional Pytroll dependencies**: None
 
 * **Other dependencies**: NumPy, OpenMP
 
@@ -130,15 +130,15 @@ repository.
 
 * **Maturity**: Mature
 
-* **PyTroll dependencies**: None
+* **Pytroll dependencies**: None
 
-* **Optional PyTroll dependencies**: None
+* **Optional Pytroll dependencies**: None
 
 * **Other dependencies**: NumPy, Scipy, Pandas, Cython (optional)
 
 * **24/7 production @**: DMI, FMI, ESTEA, SMHI, LEGMC, IMO, ECCC
 
-### PySpectral
+### Pyspectral
 
 * **Summary**: Read and manipulate satellite sensor spectral responses and solar irradiance spectra
 
@@ -150,9 +150,9 @@ repository.
 
 * **Maturity**: Mature
 
-* **PyTroll dependencies**: None
+* **Pytroll dependencies**: None
 
-* **Optional PyTroll dependencies**: None
+* **Optional Pytroll dependencies**: None
 
 * **Other dependencies**: NumPy, Scipy, h5py, Pyyaml, tqdm, requests, appdirs, Six, xlrd (optional), Matplotlib (optional)
 
@@ -161,7 +161,7 @@ repository.
 
 ### Posttroll
 
-* **Summary**: High-level messaging system for pytroll
+* **Summary**: High-level messaging system for Pytroll
 
 * **Development intensity**: Medium
 
@@ -171,9 +171,9 @@ repository.
 
 * **Maturity**: Mature
 
-* **PyTroll dependencies**: None
+* **Pytroll dependencies**: None
 
-* **Optional PyTroll dependencies**: None
+* **Optional Pytroll dependencies**: None
 
 * **Other dependencies**: Pyzmq
 
@@ -191,9 +191,9 @@ repository.
 
 * **Maturity**: Mature
 
-* **PyTroll dependencies**: Pyorbital, Posttroll, Trollsift
+* **Pytroll dependencies**: Pyorbital, Posttroll, Trollsift
 
-* **Optional PyTroll dependencies**: None
+* **Optional Pytroll dependencies**: None
 
 * **Other dependencies**: Pyzmq, NumPy, Pyinotify
 
@@ -211,9 +211,9 @@ repository.
 
 * **Maturity**: Mature
 
-* **PyTroll dependencies**: PyOrbital, PyResample
+* **Pytroll dependencies**: Pyorbital, Pyresample
 
-* **Optional PyTroll dependencies**:
+* **Optional Pytroll dependencies**:
 
 * **Other dependencies**: NumPy, Basemap (optional)
 
@@ -231,15 +231,15 @@ repository.
 
 * **Maturity**: Mature
 
-* **PyTroll dependencies**: None
+* **Pytroll dependencies**: None
 
-* **Optional PyTroll dependencies**: None
+* **Optional Pytroll dependencies**: None
 
 * **Other dependencies**: Six
 
 * **24/7 production @**: FMI, DWD, SMHI, IMO, Met Norway, ...
 
-### PyCoast
+### Pycoast
 
 * **Summary**: Python package to add coastlines, borders and rivers to raster images using data from the GSHHS and WDBII datasets
 * **Development intensity**: Low
@@ -250,15 +250,15 @@ repository.
 
 * **Docs**: <https://pycoast.readthedocs.io>
 
-* **PyTroll dependencies**: None
+* **Pytroll dependencies**: None
 
-* **Optional PyTroll dependencies**: None
+* **Optional Pytroll dependencies**: None
 
 * **Other dependencies**: Pyshp, NumPy, Pyproj, Pillow, Six
 
 * **24/7 production @**: MeteoSwiss, FMI, SMHI, ESTEA, LEGMC, IMO, ECCC, Met Norway, COMet, ...
 
-### PyDecorate
+### Pydecorate
 
 * **Summary**: Package for decorating PIL/Pillow images with logos, texts, and color scales.
 
@@ -270,9 +270,9 @@ repository.
 
 * **Docs**: <https://pydecorate.readthedocs.io>
 
-* **PyTroll dependencies**: None
+* **Pytroll dependencies**: None
 
-* **Optional PyTroll dependencies**: None
+* **Optional Pytroll dependencies**: None
 
 * **Other dependencies**: Pillow
 
@@ -290,9 +290,9 @@ repository.
 
 * **Docs**: <https://trollbufr.readthedocs.io>
 
-* **PyTroll dependencies**: None
+* **Pytroll dependencies**: None
 
-* **Optional PyTroll dependencies**: None
+* **Optional Pytroll dependencies**: None
 
 * **Other dependencies**: None
 
@@ -310,34 +310,15 @@ repository.
 
 * **Docs**: 
 
-* **PyTroll dependencies**: PyKDTree, Mpop, Posttroll, Trollsift, pytroll-schedule, PyResample, PyCoast
+* **Pytroll dependencies**: PyKDTree, Mpop, Posttroll, Trollsift, pytroll-schedule, Pyresample, Pycoast
 
-* **Optional PyTroll dependencies**:
+* **Optional Pytroll dependencies**:
 
 * **Other dependencies**: Pyinotify, netifaces, Pillow
 
 * **24/7 production @**: FMI, SMHI, Met Norway, ...
 
-### Trollduction
-* **Summary**: Framework for operational weather satellite image batch production.
-
-* **Development intensity**: Frozen. Being replaced by Trollflow
-
-* **Maturity**: Mature
-
-* **GitHub**: <https://github.com/pytroll/trollduction>
-
-* **Docs**: <https://trollduction.readthedocs.io>
-
-* **PyTroll dependencies**: Mpop, Posttroll, PyResample, PyKDTree, Trollimage, PyOrbital, Trollsift, Pytroll-schedule, Pytroll-collectors
-
-* **Optional PyTroll dependencies**: None
-
-* **Other dependencies**: Netifaces, netCDF4
-
-* **24/7 production @**: DWD, SMHI
-
-### Trollflow
+### Trollflow2
 
 * **Summary**: A small Python workflow execution framework
 
@@ -345,38 +326,17 @@ repository.
 
 * **Maturity**: Becoming mature
 
-* **GitHub**: <https://github.com/pytroll/trollflow>
+* **GitHub**: <https://github.com/pytroll/trollflow2>
 
 * **Docs**: 
 
-* **PyTroll dependencies**: None
+* **Pytroll dependencies**: None
 
-* **Optional PyTroll dependencies**: None
+* **Optional Pytroll dependencies**: None
 
 * **Other dependencies**: Pyyaml, Mock
 
 * **24/7 production @**: FMI, DWD
-
-### Trollflow-sat
-
-* **Summary**: Trollflow plug-ins for satellite data processing
-
-* **Development intensity**: Medium
-
-* **Maturity**: Becoming mature
-
-* **GitHub**: <https://github.com/pytroll/trollflow-sat>
-
-* **Docs**: 
-
-* **PyTroll dependencies**: SatPy or mpop, PyResample, Posttroll, Trollsift
-
-* **Optional PyTroll dependencies**: PyOrbital
-
-* **Other dependencies**: Pyyaml
-
-* **24/7 production @**: FMI, DWD
-
 
 ### PyGAC
 
@@ -390,9 +350,9 @@ repository.
 
 * **Docs**: <https://pygac.readthedocs.io>
 
-* **PyTroll dependencies**: PyOrbital
+* **Pytroll dependencies**: Pyorbital
 
-* **Optional PyTroll dependencies**: None
+* **Optional Pytroll dependencies**: None
 
 * **Other dependencies**: NumPy, h5py, docutils
 
@@ -410,9 +370,9 @@ repository.
 
 * **Docs**: 
 
-* **PyTroll dependencies**: None
+* **Pytroll dependencies**: None
 
-* **Optional PyTroll dependencies**: None
+* **Optional Pytroll dependencies**: None
 
 * **Other dependencies**: NumPy, Six
 
@@ -430,9 +390,9 @@ repository.
 
 * **Docs**: 
 
-* **PyTroll dependencies**: PyOrbital, Posttroll
+* **Pytroll dependencies**: Pyorbital, Posttroll
 
-* **Optional PyTroll dependencies**: None
+* **Optional Pytroll dependencies**: None
 
 * **Other dependencies**: Geoalchemy2, Sqlalchemy, Shapely, Psycop2, Paramiko
 
@@ -450,54 +410,29 @@ repository.
 
 * **Docs**: <https://aggdraw.readthedocs.io>
 
-* **PyTroll dependencies**: None
+* **Pytroll dependencies**: None
 
-* **Optional PyTroll dependencies**: None
+* **Optional Pytroll dependencies**: None
 
 * **Other dependencies**: None
 
 * **24/7 production @**: MeteoSwiss, FMI, LEGMC, SMHI, ECCC, Met Norway, ...
 
-### Mpop
+### Fogpy
 
-* **Summary**: Being replaced by SatPy
+* **Summary**: Retrieve fog from SEVIRI or ABI
 
-* **Development intensity**: Low. Frozen: No new features are being implemented, only bug-fixes.
+* **Development intensity**: Low
 
-* **Maturity**: Mature
+* **Maturity**: experimental
 
-* **GitHub**: <https://github.com/pytroll/mpop>
+* **GitHub**: <https://github.com/pytroll/fogpy>
 
-* **Docs**: <https://mpop.readthedocs.io>
+* **Docs**: <https://fogpy.readthedocs.io>
 
-* **PyTroll dependencies**: PyResample
+* **Pytroll dependencies**: Satpy
 
-* **Optional PyTroll dependencies**: Mipp, PySpectral, PyOrbital, PyGAC
-
-* **Other dependencies**: NumPy, Pillow
-
-* **In 24/7 production @**: FMI, SMHI, DMI, Met Norway, MeteoSwiss, DWD, COMet, ESTEA, LEGMC, IMO... 
-
-### Mipp
-
-* **Summary**: Lower level library providing mainly level-1 readers for mpop (SatPy). Originally first of all for HRIT/XRIT data formats (geostationary satellites) but also supports some SAR data formats. 
-
-* **Development intensity**: Low. Most readers are now implemented in SatPy.
-
-* **Maturity**: Mature
-
-* **GitHub**: <https://github.com/pytroll/mipp>
-
-* **Docs**: <https://mipp.readthedocs.io>
-
-* **PyTroll dependencies**: None
-
-* **Optional PyTroll dependencies**: None
-
-* **Other dependencies**: NumPy
-
-* **In 24/7 production @**: FMI, DMI, SMHI, Met Norway, MeteoSwiss, DWD, COMet, LEGMC, IMO, ESTEA...
-
+* **24/7 production @**: N/A
 
 ## Pytroll runners
 
@@ -505,7 +440,7 @@ Below we list various Pytroll runners for specific tasks and applications. Many 
 
 ### Pytroll-cspp-runner
 
-* **Summary**: PyTroll runner for the SNPP/JPSS pre-processing (RDR to SDR) with the CSPP package
+* **Summary**: Pytroll runner for the SNPP/JPSS pre-processing (RDR to SDR) with the CSPP package
 
 * **Development intensity**: Low
 
@@ -515,9 +450,9 @@ Below we list various Pytroll runners for specific tasks and applications. Many 
 
 * **Docs**: 
 
-* **PyTroll dependencies**: Posttroll
+* **Pytroll dependencies**: Posttroll
 
-* **Optional PyTroll dependencies**: None
+* **Optional Pytroll dependencies**: None
 
 * **Other dependencies**: None
 
@@ -525,7 +460,7 @@ Below we list various Pytroll runners for specific tasks and applications. Many 
 
 ### Pytroll-aapp-runner
 
-* **Summary**: PyTroll runner for NOAA/Metop pre-processing with the NWPSAF/AAPP package
+* **Summary**: Pytroll runner for NOAA/Metop pre-processing with the NWPSAF/AAPP package
 
 * **Development intensity**: Low
 
@@ -535,9 +470,9 @@ Below we list various Pytroll runners for specific tasks and applications. Many 
 
 * **Docs**: 
 
-* **PyTroll dependencies**: Posttroll
+* **Pytroll dependencies**: Posttroll
 
-* **Optional PyTroll dependencies**: None
+* **Optional Pytroll dependencies**: None
 
 * **Other dependencies**: None
 
@@ -545,7 +480,7 @@ Below we list various Pytroll runners for specific tasks and applications. Many 
 
 ### Pytroll-pps-runner
 
-* **Summary**: PyTroll runner for the NWCSAF/PPS cloud processing package
+* **Summary**: Pytroll runner for the NWCSAF/PPS cloud processing package
 
 * **Development intensity**: Low
 
@@ -555,9 +490,9 @@ Below we list various Pytroll runners for specific tasks and applications. Many 
 
 * **Docs**: 
 
-* **PyTroll dependencies**: Posttroll
+* **Pytroll dependencies**: Posttroll
 
-* **Optional PyTroll dependencies**: None
+* **Optional Pytroll dependencies**: None
 
 * **Other dependencies**: None
 
@@ -575,9 +510,9 @@ Below we list various Pytroll runners for specific tasks and applications. Many 
 
 * **Docs**: 
 
-* **PyTroll dependencies**: Posttroll, Mpop
+* **Pytroll dependencies**: Posttroll, Mpop
 
-* **Optional PyTroll dependencies:** None
+* **Optional Pytroll dependencies:** None
 
 * **Other dependencies**: None
 
@@ -585,7 +520,7 @@ Below we list various Pytroll runners for specific tasks and applications. Many 
 
 ### Pytroll-modis-runner
 
-* **Summary**: PyTroll runner for MODIS pre-processing (PDS to level-1) with SeaDAS
+* **Summary**: Pytroll runner for MODIS pre-processing (PDS to level-1) with SeaDAS
 
 * **Development intensity**: Low
 
@@ -595,13 +530,105 @@ Below we list various Pytroll runners for specific tasks and applications. Many 
 
 * **Docs**: 
 
-* **PyTroll dependencies**: Posttroll
+* **Pytroll dependencies**: Posttroll
 
-* **Optional PyTroll dependencies**: None
+* **Optional Pytroll dependencies**: None
 
 * **Other dependencies**: None
 
 * **24/7 production @**: SMHI, Met Norway
+
+## Obsolete, historical, retired, and archived packages
+
+Those packages have served their purpose, but are no longer being actively
+developed.  Their use is not recommended.  If you are still using them,
+we recommend upgrading to the current replacement.
+
+### Mpop
+
+* **Replacement**: Satpy
+
+* **GitHub**: <https://github.com/pytroll/mpop>
+
+* **Docs**: <https://mpop.readthedocs.io>
+
+* **Pytroll dependencies**: Pyresample
+
+* **Optional Pytroll dependencies**: Pyspectral, Pyorbital, PyGAC
+
+* **Other dependencies**: NumPy, Pillow
+
+* **In 24/7 production @**: FMI, SMHI, DMI, Met Norway, MeteoSwiss, DWD, COMet, ESTEA, LEGMC, IMO... 
+
+### Mipp
+
+* **Replacement**: Satpy
+
+* **Summary**: Lower level library providing mainly level-1 readers for mpop (Satpy). Originally first of all for HRIT/XRIT data formats (geostationary satellites) but also supports some SAR data formats. 
+
+* **GitHub**: <https://github.com/pytroll/mipp>
+
+* **Docs**: <https://mipp.readthedocs.io>
+
+* **Pytroll dependencies**: None
+
+* **Optional Pytroll dependencies**: None
+
+* **Other dependencies**: NumPy
+
+* **In 24/7 production @**: FMI, DMI, SMHI, Met Norway, MeteoSwiss, DWD, COMet, LEGMC, IMO, ESTEA...
+
+### Trollduction
+
+* **Replacement**: Trollflow2
+
+* **Summary**: Framework for operational weather satellite image batch production.
+
+* **GitHub**: <https://github.com/pytroll/trollduction>
+
+* **Docs**: <https://trollduction.readthedocs.io>
+
+* **Pytroll dependencies**: Mpop, Posttroll, Pyresample, PyKDTree, Trollimage, Pyorbital, Trollsift, Pytroll-schedule, Pytroll-collectors
+
+* **Optional Pytroll dependencies**: None
+
+* **Other dependencies**: Netifaces, netCDF4
+
+* **24/7 production @**: DWD, SMHI
+
+### Trollflow
+
+* **Replacement**: Trollflow2
+
+* **GitHub**: <https://github.com/pytroll/trollflow>
+
+* **Docs**: 
+
+* **Pytroll dependencies**: None
+
+* **Optional Pytroll dependencies**: None
+
+* **Other dependencies**: Pyyaml, Mock
+
+* **24/7 production @**: FMI, DWD
+
+### Trollflow-sat
+
+* **Replacement**: Trollflow2
+
+* **Summary**: Trollflow plug-ins for satellite data processing
+
+* **GitHub**: <https://github.com/pytroll/trollflow-sat>
+
+* **Docs**: 
+
+* **Pytroll dependencies**: Satpy or mpop, Pyresample, Posttroll, Trollsift
+
+* **Optional Pytroll dependencies**: Pyorbital
+
+* **Other dependencies**: Pyyaml
+
+* **24/7 production @**: FMI, DWD
 
 
 ## Institutes/entities

--- a/pytroll_packages_overview.md
+++ b/pytroll_packages_overview.md
@@ -336,7 +336,7 @@ individual package documentation for details or limitations.
 
 * **Other dependencies**: Pyyaml, Mock
 
-* **24/7 production @**: FMI, DWD
+* **24/7 production @**: FMI, DWD, SMHI
 
 ### PyGAC
 


### PR DESCRIPTION
Update the packages overview:

- Change spelling of various packages to reflect the current consensus (no mid-word capitalisation).
- Add a new section for retired packages and move mipp, mpop, trollflow, trollflow-sat, and trollduction there.
- Add Fogpy.
- Clarify that all packages need Python 3 and that Python 2 is no longer supported.

[x] Closes #20 (mostly, there are some aspects I didn't touch like operational use, as I don't have a clue what is used where operationally)