### PR TITLE
Update slack invite URL to not use Heroku app

### DIFF
--- a/index.md
+++ b/index.md
@@ -30,8 +30,6 @@ For some pytroll examples, you can have a look at the [Pytroll Gallery](gallery.
 
 ## Getting in touch
 
-<script async defer src="https://pytrollslackin.herokuapp.com/slackin.js"></script>
-
 If you want to contact us, we will be very happy to chat with you on the [Pytroll slack](https://pytroll.slack.com).
 To get access you must invite yourself to the slack team by going
 [here](https://join.slack.com/t/pytroll/shared_invite/zt-1ft5pjuqq-RKJ6OBk2VWjDGwpuYoQiXA).

--- a/index.md
+++ b/index.md
@@ -33,9 +33,9 @@ For some pytroll examples, you can have a look at the [Pytroll Gallery](gallery.
 <script async defer src="https://pytrollslackin.herokuapp.com/slackin.js"></script>
 
 If you want to contact us, we will be very happy to chat with you on the [Pytroll slack](https://pytroll.slack.com).
-To get access you must invite yourself to the slack team by clicking on the
-above badge image or go [here](https://pytrollslackin.herokuapp.com/). This
-invite page can sometimes take a while to load so please be patient.
+To get access you must invite yourself to the slack team by going
+[here](https://join.slack.com/t/pytroll/shared_invite/zt-1ft5pjuqq-RKJ6OBk2VWjDGwpuYoQiXA).
+If you have issues joining the slack, please send an email to the mailing list below.
 
 Alternatively, you can send messages mailing list: <https://groups.google.com/group/pytroll>.
 


### PR DESCRIPTION
As discussed in the monthly meeting, Heroku is no longer offering a free tier for compute hosting. We use Heroku with a simple web app that I found on github to allow users to invite themselves. This PR replaces the use of that app with a simple slack URL that allows a maximum of 100 invites and never expires. I have configured it to give me a notification for everyone who joins using this URL.