### PR TITLE
Add history of pytroll page

### DIFF
--- a/history.md
+++ b/history.md
@@ -3,7 +3,7 @@ title: History of Pytroll
 ---
 
 The open source collaboration that became Pytroll started in 2009 by a handful
-of developers at the Danish Met Service (DMI) and SMHI including current
+of developers at the Danish Meteorological Institute (DMI) and the Swedish Meteorological and Hydrological Institute (SMHI) including current
 maintainers Martin Raspaud and Adam Dybbroe. We realized that we had a lot in
 common. We all liked Python and were solving or wanted to solve a lot of
 similar problems. There was also a desire to get rid of ill-suited proprietary

--- a/history.md
+++ b/history.md
@@ -9,8 +9,19 @@ common. We all liked Python and were solving or wanted to solve a lot of
 similar problems. There was also a desire to get rid of ill-suited proprietary
 software in our satellite data production systems. At some point around 2010
 the effort had grown big enough that we felt it needed a name. The "troll" in
-Pytroll hints at the Nordic/Scandinavian heritage. Soon after colleagues at
-FMI (the Finnish Met Service) and the Icelandic Met Service joined. The name
+Pytroll hints at the Nordic/Scandinavian heritage. The name
 was not liked equally by all of us, but it was the best we could come up with.
 
 Now we are stuck with it. 😀
+
+In 2013, a first Pytroll workshop open to anyone was organized, where colleagues from other meteorological services (among which Finland, Iceland, and Switzerland) joined. A set of presentations was shown and the session was recorded (https://www.youtube.com/watch?v=WEk95gxO8sE)
+
+Following this, the interest in Pytroll and the number of NMS involved grew, so that a small but steady community of developers maintained and developed the code of the different modules.
+The project also caught the attention of some colleagues from EUMETSAT, who started using it internally for tasks like validation of different products. With their help, some new data readers were developed including the reader for the Native SEVIRI data format.
+
+In 2015, a discussion between developers of Pytroll and Polar2Grid lead to the realization that both projects were covering common functionality, and a few months later a decision was made to merge the functionality of both code bases. The first draft of satpy was pushed to github. Satpy has since been the most visible and known part of the Pytroll ecosystem.
+
+Since then, Pytroll has gained support from many NMS in Europe and outside, but also from EUMETSAT and the academic world, due to the dedication of its developers and the high quality of the software.
+
+To summarize the development of Pytroll, a video was made that show the commit history of the different modules between 2009 and 2019: https://www.youtube.com/watch?v=qwBvTT9h_Qs
+

--- a/history.md
+++ b/history.md
@@ -4,13 +4,13 @@ title: History of Pytroll
 
 The open source collaboration that became Pytroll started in 2009 by a handful
 of developers at the Danish Meteorological Institute (DMI) and the Swedish Meteorological and Hydrological Institute (SMHI) including current
-maintainers Martin Raspaud and Adam Dybbroe. We realized that we had a lot in
-common. We all liked Python and were solving or wanted to solve a lot of
+maintainers Martin Raspaud and Adam Dybbroe. They realized that they had a lot in
+common: they all liked Python and were solving or wanted to solve a lot of
 similar problems. There was also a desire to get rid of ill-suited proprietary
-software in our satellite data production systems. At some point around 2010
-the effort had grown big enough that we felt it needed a name. The "troll" in
+software in their respective satellite data production systems. At some point around 2010
+the effort had grown big enough that they felt it needed a name. The "troll" in
 Pytroll hints at the Nordic/Scandinavian heritage. The name
-was not liked equally by all of us, but it was the best we could come up with.
+was not liked equally by all, but it was the best they could come up with.
 
 Now we are stuck with it. 😀
 

--- a/history.md
+++ b/history.md
@@ -1,0 +1,16 @@
+---
+title: History of Pytroll
+---
+
+The open source collaboration that became Pytroll started in 2009 by a handful
+of developers at the Danish Met Service (DMI) and SMHI including current
+maintainers Martin Raspaud and Adam Dybbroe. We realized that we had a lot in
+common. We all liked Python and were solving or wanted to solve a lot of
+similar problems. There was also a desire to get rid of ill-suited proprietary
+software in our satellite data production systems. At some point around 2010
+the effort had grown big enough that we felt it needed a name. The "troll" in
+Pytroll hints at the Nordic/Scandinavian heritage. Soon after colleagues at
+FMI (the Finnish Met Service) and the Icelandic Met Service joined. The name
+was not liked equally by all of us, but it was the best we could come up with.
+
+Now we are stuck with it. 😀

--- a/index.md
+++ b/index.md
@@ -81,5 +81,6 @@ at the [Workshops](./workshops/index.md) page.
 
 ## Other Links
 
+- [History](history.md)
 - [Logos](logos/index.md)
 


### PR DESCRIPTION
Closes #33 

I took @adybbroe's comment [here](https://github.com/pytroll/pytroll.github.io/issues/33#issuecomment-1634814296) and turned it into a separate page on the history of pytroll.