### PR TITLE
replace twitter by mastodon

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -46,7 +46,7 @@ relative_links:
 minima:
   skin: dark
   social_links:
-    - { platform: twitter, user_url: "https://twitter.com/pytrollorg" }
+    - { platform: mastodon, user_url: "https://mastodon.social/@pytroll@fosstodon.org" }
     - { platform: github, user_url: "https://github.com/pytroll" }
 header_pages:
   - index.md

--- a/coc_info.md
+++ b/coc_info.md
@@ -10,7 +10,7 @@ repositories.
 This code of conduct applies to the
 project space (GitHub) as well as the public space online and offline when
 an individual is representing the project or the community. Online examples
-of this include the Pytroll Slack team, mailing list, and the Pytroll twitter
+of this include the Pytroll Slack team, mailing list, and the Pytroll mastodon
 account. This code of conduct also applies to in-person situations like
 Pytroll Contributor Weeks (PCW), conference meet-ups, or any other time when
 the project is being represented.

--- a/index.md
+++ b/index.md
@@ -37,7 +37,7 @@ If you have issues joining the slack, please send an email to the mailing list b
 
 Alternatively, you can send messages mailing list: <https://groups.google.com/group/pytroll>.
 
-<a href="https://twitter.com/PytrollOrg?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-show-count="false">Follow @PytrollOrg</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+<button class="mastodon-follow" data-followtype="remote" data-account="@pytroll@fosstodon.org"></button>
 
 ## Announcements
 


### PR DESCRIPTION
Remove all references to twitter (which ceased to exist in 2023) and link to mastodon accounts instead.